### PR TITLE
perf(setup.sh): use less bcrypt rounds for nginx pass hash

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -332,8 +332,14 @@ fi
 
 info_log "Finishing..."
 
+# in caddy basic_auth, hashed password is loaded in memory
+# in nginx basic_auth, websites slows down a lot if bcrypt rounds number is high as the hashed password file is checked again and again on every request.
+# This is only applicable when using basic_auth, not with authelia
+bcryptRounds=12
+if [[ "$proxy" == "nginx" && "$with_authelia" == false ]]; then bcryptRounds=6; fi
+
 # https://www.baeldung.com/linux/bcrypt-hash#using-htpasswd
-password=$(htpasswd -bnBC 12 "" "$password" | cut -d : -f 2)
+password=$(htpasswd -bnBC "$bcryptRounds" "" "$password" | cut -d : -f 2)
 
 gen_hex() { openssl rand -hex "$1"; }
 


### PR DESCRIPTION
when using nginx basic_auth, higher bcrypt rounds for hashing password result in degraded performance as the password file has be checked again and again on every authenticated route. Not applicable when using authelia.

This doesn't affect caddy.