### PR TITLE
fix: storage cors issue

### DIFF
--- a/docker/volumes/caddy/snippets/cors.conf
+++ b/docker/volumes/caddy/snippets/cors.conf
@@ -1,0 +1,19 @@
+# https://kalnytskyi.com/posts/setup-cors-caddy-2/
+# Currently cannot find a way to copy header Access-Control-Request-Headers in request
+# and paste its value in response header Access-Control-Allow-Headers. That's why using *
+(cors) {
+	@cors_preflight method OPTIONS
+	@cors header Origin {args.0}
+
+	handle @cors_preflight {
+		header Access-Control-Allow-Origin "{args.0}"
+		header Access-Control-Allow-Methods "GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS,TRACE,CONNECT"
+		header Access-Control-Allow-Headers *
+		header Access-Control-Max-Age "86400";
+		respond "" 204
+	}
+
+	handle @cors {
+		header Access-Control-Allow-Origin "{args.0}"
+	}
+}

--- a/docker/volumes/nginx/snippets/cors.conf
+++ b/docker/volumes/nginx/snippets/cors.conf
@@ -1,0 +1,11 @@
+if ($request_method = OPTIONS) {
+    add_header 'Access-Control-Allow-Origin' '*';
+    add_header 'Access-Control-Allow-Methods' 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS,TRACE,CONNECT';
+    add_header 'Access-Control-Allow-Headers' "$http_access_control_request_headers";
+    add_header 'Access-Control-Max-Age' 86400;
+    add_header 'Content-Length' 0;
+    add_header 'Content-Type' 'text/plain charset=UTF-8';
+    return 204;
+}
+
+add_header 'Access-Control-Allow-Origin' '*';


### PR DESCRIPTION
- this bug got introduced when requests  on /storage were directly proxied to storage service.

- earlier requests were proxied to kong, and kong took care of adding cors headers. Can't use kong anymore as it breaks resumable uploads from dashboard.