### PR TITLE
feat: add deno_cache volume

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -327,6 +327,7 @@ services:
     restart: unless-stopped
     volumes:
       - ./volumes/functions:/home/deno/functions:Z
+      - deno_cache:/root/.cache/deno
     depends_on:
       analytics:
         condition: service_healthy
@@ -513,3 +514,4 @@ services:
 
 volumes:
   db-config:
+  deno_cache:


### PR DESCRIPTION
Add a named deno_cache volume to the functions service so that deno can reuse its cache across container restarts, reducing repeated downloads.