### PR TITLE
refactor(functions): replace imported serve with built-in Deno.serve

### DIFF
--- a/docker/volumes/functions/hello/index.ts
+++ b/docker/volumes/functions/hello/index.ts
@@ -2,9 +2,7 @@
 // https://deno.land/manual/getting_started/setup_your_environment
 // This enables autocomplete, go to definition, etc.
 
-import { serve } from "https://deno.land/std@0.177.1/http/server.ts"
-
-serve(async () => {
+Deno.serve(async () => {
   return new Response(
     `"Hello from Edge Functions!"`,
     { headers: { "Content-Type": "application/json" } },

--- a/docker/volumes/functions/main/index.ts
+++ b/docker/volumes/functions/main/index.ts
@@ -1,4 +1,3 @@
-import { serve } from 'https://deno.land/std@0.131.0/http/server.ts'
 import * as jose from 'https://deno.land/x/jose@v4.14.4/index.ts'
 
 console.log('main function started')
@@ -30,7 +29,7 @@ async function verifyJWT(jwt: string): Promise<boolean> {
   return true
 }
 
-serve(async (req: Request) => {
+Deno.serve(async (req: Request) => {
   if (req.method !== 'OPTIONS' && VERIFY_JWT) {
     try {
       const token = getAuthToken(req)


### PR DESCRIPTION
use the built-in Deno.serve API instead of the using serve package, reducing external dependencies