### PR TITLE
chore: use sh interpreter in kong entrypoint

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -104,7 +104,7 @@ services:
       DASHBOARD_USERNAME: ${DASHBOARD_USERNAME}
       DASHBOARD_PASSWORD: ${DASHBOARD_PASSWORD}
       KONG_PORT_MAPS: "443:8000,443:8443"
-    entrypoint: ["/bin/bash", "/home/kong/kong-entrypoint.sh"]
+    entrypoint: ["/bin/sh", "/home/kong/kong-entrypoint.sh"]
 
   auth:
     container_name: supabase-auth

--- a/docker/volumes/api/kong-entrypoint.sh
+++ b/docker/volumes/api/kong-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Custom entrypoint for Kong that builds Lua expressions for request-transformer
 # and performs environment variable substitution in the declarative config.
 


### PR DESCRIPTION
- use /bin/sh in shebang in kong-entrypoint.sh
